### PR TITLE
Allow for passwordless certs

### DIFF
--- a/pypki2/__init__.py
+++ b/pypki2/__init__.py
@@ -101,6 +101,16 @@ def confirm_password(input_function, load_function):
 
     return password
 
+
+def get_password_or_nopass(filename, config):
+    """Prompt the user for a password for an already configured cert.
+    If the user's config specifies 'nopass', then just return None"""
+
+    if 'nopass' not in config or config['nopass'].lower() != 'true':
+        return get_password(filename)
+    return None
+
+
 def get_password(filename):
     if sys.version_info.major == 3:
         return bytes(getpass('PKI password for {0}: '.format(filename)), encoding='utf-8')
@@ -108,6 +118,22 @@ def get_password(filename):
         return getpass('PKI password for {0}: '.format(filename))
     else:
         raise PyPKI2Exception('Unknown version of Python.')
+
+
+def create_loader_config(path, passwd=None):
+    """Create a loader configuration
+
+    Arguments:
+    path -- the path to the certificate file
+    passwd -- the password entered by the user. (This should not be stored.
+              In this case it is passed in to check for an empty password,
+              and not stored)
+    """
+
+    nopass = passwd is None or len(passwd) == 0
+    return {'path': path,
+            'nopass': str(nopass).lower()}
+
 
 def get_cert_path(prompt):
     path = None
@@ -186,7 +212,9 @@ class _P12Loader(object):
         if self.config.has('p12') and 'path' in self.config.get('p12') and _openssl_support:
             self.filename = self.config.get('p12')['path']
 
-            input_func = partial(get_password, self.filename)
+            input_func = partial(get_password_or_nopass,
+                                 self.filename,
+                                 self.config.get('p12'))
             load_func = partial(_load_p12, self.filename)
             self.password = confirm_password(input_func, load_func)
             self.complete = True
@@ -198,7 +226,8 @@ class _P12Loader(object):
             input_func = partial(get_password, self.filename)
             load_func = partial(_load_p12, self.filename)
             self.password = confirm_password(input_func, load_func)
-            self.config.set('p12', { 'path': self.filename })
+            config = create_loader_config(self.filename, self.password)
+            self.config.set('p12', config)
             self.complete = True
 
         else:
@@ -240,7 +269,9 @@ class _PEMLoader(object):
         if self.config.has('pem') and 'path' in self.config.get('pem'):
             self.filename = self._combine_pem_files(self.config.get('pem'))
 
-            input_func = partial(get_password, self.filename)
+            input_func = partial(get_password_or_nopass,
+                                 self.filename,
+                                 self.config.get('pem'))
             load_func = partial(_load_pem, self.filename)
             self.password = confirm_password(input_func, load_func)
             self.complete = True
@@ -252,7 +283,8 @@ class _PEMLoader(object):
             input_func = partial(get_password, self.filename)
             load_func = partial(_load_pem, self.filename)
             self.password = confirm_password(input_func, load_func)
-            self.config.set('pem', { 'path': self.filename })
+            config = create_loader_config(self.filename, self.password)
+            self.config.set('pem', config)
             self.complete = True
 
     def new_context(self, protocol=ssl.PROTOCOL_SSLv23):


### PR DESCRIPTION
We wanted to run some automated scripts using pypki2, so I added the ability to configure passwordless certificates in this way.

I added a "nopass" key to each of the "pem" and "p12" configs.  If "nopass" is "true" then the user will not be prompted for a password.  "nopass" is set to true during initial configuration if the user enters a empty password.

To avoid being prompted for my p12 certs even though I had configured my pem certs, I changed the way the default certificate loader is chosen.
1. The user can specify the "default" key to be "pem" or "p12".  If that key is set, choose the loader associated with its value
2. If the .mypki file only has one of "pem" or "p12" then try that one first.