### PR TITLE
Fix is_patched check for Python 2 compatibility

### DIFF
--- a/pypki2/pypki2.py
+++ b/pypki2/pypki2.py
@@ -52,7 +52,7 @@ def _is_patched(new_init):
             raise Exception('Error: pypki2 is not patched or unpatched')
 
     elif sys.version_info.major == 2:
-        if httplib.HTTPSConnection.__init__ == new_init:
+        if httplib.HTTPSConnection.__init__.__func__ == new_init:
             return True
         elif httplib.HTTPSConnection.__init__ == _orig_HTTPSConnection_init:
             return False


### PR DESCRIPTION
In Python 2, after the patch is applied, the new init function is transparently wrapped in an unbound method, and so comparing `httplib.HTTPSConnection.__init__` directly with the `new_init` function will always fail. To fix this, compare `new_init` instead with the wrapped function.

Since both `patch()` and `unpatch()` call `is_patched()` before running, this bug makes it effectively impossible to toggle the patch in Python 2.