### PR TITLE
Prevent PermissionError with pypki2pip

### DIFF
--- a/pypki2pip/wrapper.py
+++ b/pypki2pip/wrapper.py
@@ -36,9 +36,18 @@ def pip(*args, **kwargs):
     new_args = [ arg for arg in new_args if '--client-cert=' not in arg ]
     new_args = [ arg for arg in new_args if '--cert=' not in arg ]
 
-    with NamedTemporaryFile() as temp_key:
-        dump_key(temp_key)
-        new_args.append('--client-cert={0}'.format(temp_key.name))
-        new_args.append('--cert={0}'.format(ca_path()))
-        new_args.append('--disable-pip-version-check')
-        _pip.main(new_args)
+	#create the temp key and dump cert and key to it
+	temp_key = NamedTemporaryFile(delete=False)
+	demp_key(temp_key)
+	temp_key.close()	
+	
+	#use file in args
+	new_args.append('--client-cert={0}'.format(temp_key.name))
+	new_args.append('--cert={0}'.format(ca_path()))
+	new_args.append('--disable-pip-version-check')
+		
+	#run pip
+	_pip.main(new_args)
+
+	#ensure temp file is closed
+	os.unlink(temp_key)


### PR DESCRIPTION
A permission error is thrown when trying to use pypki2pip. The
PermissionError is thrown because pip.main is unable to use the open
NamedTemporaryFile. If the file is closed, pip.main can access the cert
file and use it to connect.